### PR TITLE
Computing ranking_matrix using np.argsort twice on every row.

### DIFF
--- a/src/pyDRMetrics/coranking_matrix.py
+++ b/src/pyDRMetrics/coranking_matrix.py
@@ -7,17 +7,7 @@ D - distance matrix
 '''
 def ranking_matrix(D):    
     D = np.array(D)    
-    R = np.zeros(D.shape)
-    m = len(R)
-    
-    for i in range(m):
-        for j in range(m):
-            Rij = 0
-            for k in range(m):
-                if (D[i,k] < D[i,j]) or (math.isclose(D[i,k], D[i,j]) and k < j ):
-                    Rij += 1
-            R[i,j] = Rij
-            
+    R = [np.argsort(np.argsort(row)) for row in D]
     return R
 
 '''

--- a/src/pyDRMetrics/coranking_matrix.py
+++ b/src/pyDRMetrics/coranking_matrix.py
@@ -7,6 +7,17 @@ D - distance matrix
 '''
 def ranking_matrix(D):    
     D = np.array(D)    
+    # R = np.zeros(D.shape)
+    # m = len(R)
+    
+    # for i in range(m):
+    #     for j in range(m):
+    #         Rij = 0
+    #         for k in range(m):
+    #             if (D[i,k] < D[i,j]) or (math.isclose(D[i,k], D[i,j]) and k < j ):
+    #                 Rij += 1
+    #         R[i,j] = Rij
+            
     R = [np.argsort(np.argsort(row)) for row in D]
     return R
 


### PR DESCRIPTION
Using the original version sometimes give the same ranking to 2 very close points. Applying np.argsort doesn't allow that, but executes faster.